### PR TITLE
removed times as default font for mathmode

### DIFF
--- a/Classes/PhDThesisPSnPDF.cls
+++ b/Classes/PhDThesisPSnPDF.cls
@@ -527,7 +527,7 @@ supported!}
 \RequirePackage{textcomp}
 % Font Selection
 \ifPHD@times
-  \RequirePackage{mathptmx}  % times roman, including math (where possible)
+\renewcommand{\rmdefault}{ptm} % times
   \setFonttrue
   \message{PhDThesisPSnPDF: Using Times Roman font}
 \else


### PR DESCRIPTION
Times is the default font, and looks good for the text, however it is very difficult to get bold symbols in Math mode since the font doesn't provide them. This means that normal command '\symbolbf' doesn't work. There are a few work arounds but none are simple. Suggest using times only for the bulk text, and Computer Modern for equation/math mode. Since the characters are different in math mode anyway, it doesn't look out of place.