### PR TITLE
clarified latexmk xelatex command  line

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CUED PhD thesis template
 
 This template supports `XeLaTeX` compilation chain. To generate  PDF run
 
-    latexmk -pdf -e '$pdflatex=q/xelatex %O %S/' thesis
+    latexmk -xelatex thesis.tex
 
 ## Building your thesis - LuaLaTeX
 


### PR DESCRIPTION
reduced the arguments for latexmk (xelatex format)
latexmk is capable of performing all required actions with the -xelatex argument