### PR TITLE
extended xelatex commands with makeindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ CUED PhD thesis template
 This template supports `XeLaTeX` compilation chain. To generate  PDF run
 
     latexmk -xelatex thesis.tex
+    makeindex thesis.nlo -s nomencl.ist -o thesis.nls
+    latexmk -xelatex -g thesis.tex
 
 ## Building your thesis - LuaLaTeX
 


### PR DESCRIPTION
> latexmk -xelatex -g thesis.tex
> makeindex thesis.nlo -s nomencl.ist -o thesis.nls
> latexmk -xelatex -g thesis.tex

This ensures that the nomenclature is included if defined, latexmk is not capable of doing so unless hacked
https://mg.readthedocs.org/latexmk.html