### PR TITLE
issue 113: Aligned supervisors on P(rof.) and 112 unnecessary warning

### DIFF
--- a/Classes/PhDThesisPSnPDF.cls
+++ b/Classes/PhDThesisPSnPDF.cls
@@ -14,7 +14,7 @@
 \newcommand\fileversion{2.2.2}
 \newcommand\filedate{2016/10/20}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{PhDThesisPSnPDF}[\filedate\space A PhD thesis class file
+\ProvidesClass{Classes/PhDThesisPSnPDF}[\filedate\space A PhD thesis class file
  by Krishna Kumar (v\fileversion)]
 \typeout{https://github.com/kks32/phd-thesis-template/}
 
@@ -1204,7 +1204,8 @@ wish to left align your text}
     \ifthenelse{\equal{\@supervisor}{}}{
       % supervisor is not defined
     }{
-      \centering \Large {\@supervisorrole \@supervisor}
+	\centering
+		\Large{\@supervisorrole} \parbox[t]{200pt}{\@supervisor}
       \vspace{0.5em}
     } % supervisor is defined
   \end{minipage}
@@ -1216,8 +1217,9 @@ wish to left align your text}
   \begin{minipage}[c]{\textwidth}
     \ifthenelse{\equal{\@advisor}{}}{
       % advisor is not defined
-    }{
-      \centering \Large {\@advisorrole \@advisor}
+    }{ 
+	\centering
+		\Large{\@advisorrole} \parbox[t]{200pt}{\@advisor}
       \vspace{0.5em}
     } % advisor is defined
   \end{minipage}


### PR DESCRIPTION
regarding issue #113 :
Adapted the supervisor alignment to a parbox. 
1 open issue: If using both supervisor and advisors, they don't align all in a singular column. Might be an issue later on. Requires more coding to fix.
![image](https://cloud.githubusercontent.com/assets/6348309/20639938/d12a0974-b3d1-11e6-8655-7fe64d169386.png)

Regarding issue #112:
added Classes/ to the class definition seems to remove the warning (at least on my test).