### PR TITLE
Add pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4236,3 +4236,8 @@ endef
 -include $(HOME)/.latex-makefile/Targets.ini
 #
 # vim: noet sts=0 sw=8 ts=8
+
+.PHONY: hooks
+hooks:
+	./hooks/install.sh
+

--- a/README.md
+++ b/README.md
@@ -399,6 +399,21 @@ To include custom to-do notes in your pdf document use  `\mynote{Hey! I have a n
 		\newcommand{\listoftodos}{}
 	\fi
 
+## Git hooks
+
+You rarely want to commit changes to your TeX files which are not reflected in the PDF included in the repo.
+You can automate this process, among other things, with a git hook.
+Install the hook with `make hooks` (or see how to do it in `./hooks/install.sh`).
+Now every time you commit, if any files affecting your build have changed in this commit
+and those changes are more recent than the last modification of `thesis.pdf`,
+the default `make` target will be run and changes to `thesis.pdf` will be `git add`ed.
+
+Currently, changes to any tex/pdf/eps/png/cls files are picked up.
+This can be changed in `./hooks/pre-commit`.
+
+Skip the hook with `git commit --no-verify`.
+
+`bash`-only.
 
 ## General guidelines
 [Why is it important to follow good practices and not get killed by a Velociraptor ;)](http://www.xkcd.com/292/)

--- a/hooks/install.sh
+++ b/hooks/install.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Adapted from https://gist.github.com/tilap/0590e78c9cfd8f6548f5
+
+# Basic script to set custom project hook and share it with other developpers
+#
+# cd [path-of-the-script]
+# . install.sh
+#
+# Folders usecase
+# /.git
+# /.git/hooks
+# /hooks/install.sh <- this script
+# /hooks <- path of your hooks
+
+set -e
+
+# list of hooks the script will look for
+HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
+
+PROJECT_ROOT_DIR=`git rev-parse --show-toplevel`
+
+# absolute folder path of directory into which hooks should be installed
+TGT_DIR=$PROJECT_ROOT_DIR/.git/hooks
+
+# absolute folder path of the custom hooks to deploy / current script
+SRC_DIR=$PROJECT_ROOT_DIR/hooks
+
+# relative folder path from the target dir to the source dir
+LNS_RELATIVE_PATH=../../hooks
+
+echo "Install project git hooks"
+
+for hook in $HOOK_NAMES; do
+    # if we have a custom hook to set
+    if [ -f $SRC_DIR/$hook ]; then
+      echo "> Hook $hook"
+      if [ ! -x $SRC_DIR/$hook ]; then
+          echo " > Not executable, skipping"
+          continue
+      fi
+      # If the hook already exists, is executable, and is not a symlink
+      if [ ! -h $TGT_DIR/$hook -a -x $TGT_DIR/$hook ]; then
+          echo " > Old git hook $hook disabled"
+          # append .old to disable it
+          mv $TGT_DIR/$hook $TGT_DIR/$hook.old
+      fi
+
+      # create the symlink, overwriting the file if it exists
+      echo " > Enable project git hook"
+      ln -s -f $LNS_RELATIVE_PATH/$hook $TGT_DIR/$hook
+    fi
+done

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+# look at all staged files with the given extensions;
+# if any were modified more recently than your target,
+# rebuild the target with the default `make` task,
+# and `git add` the changed target file.
+
+set -e
+
+# extensions of files which may affect what your target looks like
+extensions="tex|pdf|png|bib|eps|cls"
+
+# your target file
+tgt="thesis.pdf"
+
+for fpath in $(git diff --cached --name-only --diff-filter=ACM | grep -P "\.${extensions}" | grep -v "${tgt}")
+do
+    if test ${fpath} -nt ${tgt}; then
+        make
+        git add ${tgt}
+        break
+    fi
+done


### PR DESCRIPTION
Add a (bash-only) git hook which checks whether any important files have changed more recently than the PDF, and runs `make` if so, ensuring that the PDF always reflects the state of the source files.